### PR TITLE
explicitly set wipi driver in hostapd

### DIFF
--- a/conf/hostapd.conf
+++ b/conf/hostapd.conf
@@ -1,4 +1,5 @@
 interface=wlan0
+driver=nl80211
 ssid=kalite
 hw_mode=g
 channel=6


### PR DESCRIPTION
Some wipi adaptors need the driver explicitly configured in the hostapd conf file.  
I've tested this with my wipi adaptor (which didn't need the setting for some reason) and there were no side-effects.
